### PR TITLE
Feature/enrolments by course

### DIFF
--- a/src/Docebo/API/Enrollment/Enrollment.php
+++ b/src/Docebo/API/Enrollment/Enrollment.php
@@ -19,9 +19,11 @@ class Enrollment extends BaseApi {
    * @param string $search
    * @param int $page_size
    * @param bool $get_total_count
+   * @param array[int] $id_course
+   * @param	array[string] $code_course
    * @return JsonResponse
    */
-  public function enrollments($id_user, $status, $type, $rating, $channel, $search, $page_size, $get_total_count) {
+  public function enrollments($id_user, $status, $type, $rating, $channel, $search, $page_size, $get_total_count, $id_course, $code_course) {
     $parameters = [
       'id_user' => $id_user,
       'status' => $status,
@@ -31,6 +33,8 @@ class Enrollment extends BaseApi {
       'search' => $search,
       'page_size' => $page_size,
       'get_total_count' => $get_total_count,
+      'id_course' => $id_course,
+      'code_course' => $code_course,
     ];
 
     return $this->docebo->get(self::PATH_LIST_ENROLLMENTS, $parameters);

--- a/src/Docebo/API/Enrollment/Enrollment.php
+++ b/src/Docebo/API/Enrollment/Enrollment.php
@@ -23,7 +23,7 @@ class Enrollment extends BaseApi {
    * @param	array[string] $code_course
    * @return JsonResponse
    */
-  public function enrollments($id_user, $status, $type, $rating, $channel, $search, $page_size, $get_total_count, $id_course, $code_course) {
+  public function enrollments($id_user, $status, $type, $rating, $channel, $search, $page_size, $get_total_count, $id_course, $code_course, $get_cursor = 1) {
     $parameters = [
       'id_user' => $id_user,
       'status' => $status,
@@ -35,6 +35,7 @@ class Enrollment extends BaseApi {
       'get_total_count' => $get_total_count,
       'id_course' => $id_course,
       'code_course' => $code_course,
+      'get_cursor' => $get_cursor,
     ];
 
     return $this->docebo->get(self::PATH_LIST_ENROLLMENTS, $parameters);

--- a/src/Docebo/Docebo.php
+++ b/src/Docebo/Docebo.php
@@ -107,8 +107,8 @@ class Docebo implements DoceboInterface {
   /**
    * @inheritdoc
    */
-  public function listEnrollments($id_user = [], $status = [], $type = [], $rating = NULL, $channel = NULL, $search = NULL, $page_size = NULL, $get_total_count = FALSE) {
-    return $this->enrollment->enrollments($id_user, $status, $type, $rating, $channel, $search, $page_size, $get_total_count);
+  public function listEnrollments($id_user = [], $status = [], $type = [], $rating = NULL, $channel = NULL, $search = NULL, $page_size = NULL, $get_total_count = FALSE, $id_course = [], $code_course = []) {
+    return $this->enrollment->enrollments($id_user, $status, $type, $rating, $channel, $search, $page_size, $get_total_count, $id_course, $code_course);
   }
 
   /**
@@ -126,7 +126,6 @@ class Docebo implements DoceboInterface {
       'cursor' => $cursor,
       'page' => $page
     ];
-
     return $this->get($path, $parameters);
   }
 


### PR DESCRIPTION
Changes responding to the api changes that we have seen in the learn api

- Allow possibility to query enrolments via course id and course code
- always request the cursor (the docs say that the default behaviour will change on feb 20th)